### PR TITLE
Use quotemeta to escape pathnames

### DIFF
--- a/t/07-stack.t
+++ b/t/07-stack.t
@@ -61,7 +61,7 @@ sub check_stack {
             serial      => $serial_5,
         },
         {   package     => 'Bar',
-            filename    => qr/\(eval \d+\)\[$filename:27\]/,
+            filename    => qr/\(eval \d+\)\[\Q$filename\E:27\]/,
             line        => 1,   # line 1 if the eval text
             subroutine  => '(eval)',
             hasargs     => 0,

--- a/t/15-subroutine-location.t
+++ b/t/15-subroutine-location.t
@@ -96,7 +96,7 @@ sub check_subroutine_location {
         {
             package => 'Bar',
             subroutine => 'sub_in_eval',
-            filename => qr{^\(eval \d+\)\[$this_file:22\]$},
+            filename => qr{^\(eval \d+\)\[\Q$this_file\E:22\]$},
             source => __FILE__,
             line => 2,
             source_line => 22,


### PR DESCRIPTION
Pathnames on Windows use backslashes as dir separators, which disappear when
interpolated into the regexes, since they become escapes.

Intended to fix #21 