### PR TITLE
Blead decompile fix

### DIFF
--- a/lib/Devel/Chitin/OpTree/LISTOP.pm
+++ b/lib/Devel/Chitin/OpTree/LISTOP.pm
@@ -419,13 +419,7 @@ sub pp_split {
 
     my $children = $self->children;
 
-    my $regex_op = $children->[0];
-    my $regex = ( $regex_op->op->flags & B::OPf_SPECIAL
-                  and
-                  ! @{$regex_op->children}
-                )
-                    ? $regex_op->deparse(delimiter => "'") # regex was given as a string
-                    : $regex_op->deparse;
+    my $regex = $self->_resolve_split_expr;
 
     my @params = (
             $regex,
@@ -439,6 +433,20 @@ sub pp_split {
 
     "${target}split(" . join(', ', @params) . ')';
 }
+
+sub _resolve_split_expr {
+    my $self = shift;
+
+    my $regex_op = $self->children->[0];
+    my $regex = ( $regex_op->op->flags & B::OPf_SPECIAL
+                  and
+                  ! @{$regex_op->children}
+                )
+                    ? $regex_op->deparse(delimiter => "'") # regex was given as a string
+                    : $regex_op->deparse;
+    return $regex;
+}
+
 
 sub _resolve_split_target {
     my $self = shift;

--- a/lib/Devel/Chitin/OpTree/LISTOP.pm
+++ b/lib/Devel/Chitin/OpTree/LISTOP.pm
@@ -423,11 +423,16 @@ sub pp_split {
 
     my $regex = $self->_resolve_split_expr;
 
-    my @params = (
-            $regex,
-            $children->[ $self->_split_string_child ]->deparse,
-        );
-    if (my $n_fields = $children->[ $self->_split_limit_child ]->deparse) {
+    my @params = ( $regex );
+
+    my $i = 0;
+    $i++ if ($children->[0]->op->name eq 'pushre'
+             or
+             $children->[0]->op->name eq 'regcomp');
+
+    push @params, $children->[$i++]->deparse;  # string
+
+    if (my $n_fields = $children->[ $i++ ]->deparse) {
         push(@params, $n_fields) if $n_fields > 0;
     }
 

--- a/lib/Devel/Chitin/OpTree/LISTOP.pm
+++ b/lib/Devel/Chitin/OpTree/LISTOP.pm
@@ -441,9 +441,6 @@ sub pp_split {
     "${target}split(" . join(', ', @params) . ')';
 }
 
-sub _split_string_child { 1 }
-sub _split_limit_child { 2 }
-
 sub _resolve_split_expr {
     my $self = shift;
 

--- a/lib/Devel/Chitin/OpTree/PMOP.pm
+++ b/lib/Devel/Chitin/OpTree/PMOP.pm
@@ -124,6 +124,16 @@ sub _match_flags {
     $flags;
 }
 
+sub _resolve_split_expr {
+    my $self = shift;
+
+    return $self->_match_op('', @_);
+}
+
+sub _resolve_split_target_pmop { $_[0] }
+sub _split_string_child { 0 }
+sub _split_limit_child { 1 }
+
 1;
 
 __END__

--- a/lib/Devel/Chitin/OpTree/PMOP.pm
+++ b/lib/Devel/Chitin/OpTree/PMOP.pm
@@ -152,8 +152,6 @@ sub _resolve_split_target {
 }
 
 sub _resolve_split_target_pmop { $_[0] }
-sub _split_string_child { 0 }
-sub _split_limit_child { 1 }
 
 1;
 

--- a/lib/Devel/Chitin/OpTree/PMOP.pm
+++ b/lib/Devel/Chitin/OpTree/PMOP.pm
@@ -130,6 +130,27 @@ sub _resolve_split_expr {
     return $self->_match_op('', @_);
 }
 
+sub _resolve_split_target {
+    my $self = shift;
+
+    my $target = '';
+    if ($self->op->private & B::OPpSPLIT_ASSIGN()) {
+        if ($self->op->flags & B::OPf_STACKED()) {
+            # target is encoded as the last child op
+            $target = $self->children->[-1]->deparse;
+
+        } elsif ($self->op->private & B::OPpSPLIT_LEX()) {
+            $target = $self->_padname_sv($self->op->pmreplroot)->PV;
+
+        } else {
+            my $gv = $self->op->pmreplroot();
+            $gv = $self->_padval_sv($gv) if !ref($gv);
+            $target = '@' . $self->_gv_name($gv);
+        }
+    }
+    $target .= ' = ' if $target;
+}
+
 sub _resolve_split_target_pmop { $_[0] }
 sub _split_string_child { 0 }
 sub _split_limit_child { 1 }

--- a/t/20-optree.t
+++ b/t/20-optree.t
@@ -3,7 +3,7 @@ use warnings;
 
 use Devel::Chitin::OpTree;
 use Devel::Chitin::Location;
-use Test::More tests => 31;
+use Test::More tests => 32;
 
 use Fcntl qw(:flock :DEFAULT SEEK_SET SEEK_CUR SEEK_END);
 use POSIX qw(:sys_wait_h);
@@ -232,9 +232,8 @@ subtest regex => sub {
                                     q(my $rx;),
                                     q(my @strings = split(/$rx/, $a, 1);),
                                     q(@strings = split(/a/, $a);),
-                                    q(our @s = split('', $a);),
                                     q(@strings = split(//, $a);),
-                                    q(@strings = split(' ', $a);),
+                                    q(@strings = split(/ /, $a);),
                                     q(my($v1, $v2) = split(/$rx/, $a, 3))),  # the 3 is implicit
     );
 };
@@ -1236,6 +1235,14 @@ subtest 'perl-5.22' => sub {
         double_diamond => join("\n",    q(while (defined($_ = <<>>)) {),
                                        qq(\tprint()),
                                         q(})),
+    );
+};
+
+subtest 'perl-5.25.6 split changes' => sub {
+    _run_tests(
+        excludes_version(v5.25.6),
+        split_specials => join("\n",    q(our @s = split('', $a);),
+                                        q(my @strings = split(' ', $a))),
     );
 };
 


### PR DESCRIPTION
5.25.6 changes pp_split from a LISTOP to a PMOP, and encodes its params somewhat differently.

https://rt.cpan.org/Public/Bug/Display.html?id=118373