### PR TITLE
Anon coderef serials

### DIFF
--- a/t/22-sub-name-bug.t
+++ b/t/22-sub-name-bug.t
@@ -1,0 +1,41 @@
+#!/usr/bin/env perl
+use strict;
+use warnings; no warnings 'void';
+
+use lib 'lib';
+use lib 't/lib';
+use Devel::Chitin::TestRunner;
+use Sub::Name;
+
+run_in_debugger();
+
+Devel::Chitin::TestDB->attach();
+Devel::Chitin::TestDB->trace(1);
+
+my $main_serial = $Devel::Chitin::stack_serial[0]->[-1];
+my $serial_in_sub;
+my $anon = Sub::Name::subname 'foo' => sub {
+    $serial_in_sub = $Devel::Chitin::stack_serial[-1]->[-1];  # start testing here
+    my @a = (1, 2, 3);
+    (4, 5, 6);
+    undef $serial_in_sub;  # stop testing after this...
+};
+$anon->(7, 8, 9);
+
+package Devel::Chitin::TestDB;
+use base 'Devel::Chitin';
+
+BEGIN {
+    if (Devel::Chitin::TestRunner::is_in_test_program) {
+        eval "use Test::More tests => 3";
+    }
+}
+
+sub notify_trace {
+    return unless $serial_in_sub;
+
+    my($class, $loc) = @_;
+
+    my $stackframe = $class->stack->frame(0);
+    is($stackframe->serial, $serial_in_sub, 'serial matches');
+}


### PR DESCRIPTION
When entering an anon sub given a name via Sub::Name, DB::sub() sees that we're calling a subref, but caller() (when reporting the stack) sees a name, and therefore couldn't determine the correct serial number for that subroutine call.

DB::sub() now attempts to determine if a called anon sub has a name, and stores that name, so it can be later matched up.

It also overrides some B::*::DESTROY methods to avoid an annoyance when Class::Autouse is in effect

This fixes #14 
