### PR TITLE
Given/when for perl-blead

### DIFF
--- a/lib/Devel/Chitin/OpTree.pm
+++ b/lib/Devel/Chitin/OpTree.pm
@@ -690,6 +690,10 @@ my %scopelike_ops = (
     pp_entergiven => 1,
     enterwhile => 1,
     pp_enterwhile => 1,
+    entergiven => 1,
+    pp_entergiven => 1,
+    enterwhereso => 1,
+    pp_enterwhereso => 1,
 );
 sub is_scopelike {
     my $self = shift;

--- a/lib/Devel/Chitin/OpTree.pm
+++ b/lib/Devel/Chitin/OpTree.pm
@@ -940,6 +940,8 @@ sub _indent_block_text {
     my $newlines = $text =~ s/\n/\n\t/g;
     if ($newlines or $params{force_multiline}) {
         "\n\t" . $text . "\n";
+    } elsif ($params{noindent}) {
+        $text;
     } else {
         " $text ";
     }

--- a/lib/Devel/Chitin/OpTree/BINOP.pm
+++ b/lib/Devel/Chitin/OpTree/BINOP.pm
@@ -362,9 +362,7 @@ sub pp_aelem {
 
 sub pp_smartmatch {
     my $self = shift;
-    if ($self->op->flags & B::OPf_SPECIAL) {
-        $self->last->deparse;
-    }
+    $self->last->deparse;
 }
 
 sub pp_lslice {

--- a/lib/Devel/Chitin/OpTree/BINOP.pm
+++ b/lib/Devel/Chitin/OpTree/BINOP.pm
@@ -186,9 +186,23 @@ sub pp_leaveloop {
     if ($enterloop->op->name eq 'enteriter') {
         return $self->_deparse_foreach;
 
+    } elsif ($enterloop->op->name eq 'entergiven') {
+        return $self->_deparse_given;
+
     } else {
         return $self->_deparse_while_until;
     }
+}
+
+sub _deparse_given {
+    my $self = shift;
+
+    my $enter_op = $self->first;
+    my $topic_op = $enter_op->first;
+    my $topic = $topic_op->deparse;
+    my $block_content = $topic_op->sibling->deparse(omit_braces => 1);
+
+    "given ($topic) {$block_content}";
 }
 
 sub _deparse_while_until {

--- a/lib/Devel/Chitin/OpTree/LISTOP.pm
+++ b/lib/Devel/Chitin/OpTree/LISTOP.pm
@@ -88,7 +88,9 @@ sub pp_leave {
 
     $deparsed = $self->_indent_block_text($deparsed, %params);
 
-    $block_declaration . "{$deparsed}";
+    my($open_brace, $close_brace) = $params{omit_braces} ? ('','') : ('{', '}');
+
+    join('', $block_declaration, $open_brace, $deparsed, $close_brace);
 }
 *pp_scope = \&pp_leave;
 *pp_leavetry = \&pp_leave;

--- a/lib/Devel/Chitin/OpTree/UNOP.pm
+++ b/lib/Devel/Chitin/OpTree/UNOP.pm
@@ -532,15 +532,16 @@ sub pp_leavewhereso {
     my $condition_op = $enter_op->first;
     my $condition_deparsed = $condition_op->deparse;
     my $block_op = $condition_op->sibling;
-    my $block_deparsed = $block_op->deparse(force_multiline => 1);
 
     my $keyword = $condition_op->op->name eq 'smartmatch'
                     ? 'whereis'
                     : 'whereso';
 
     if ($self->_is_postfix_whereso) {
-        "$block_deparsed $keyword ($condition_deparsed)"
+        my $block_deparsed = $block_op->deparse(omit_braces => 1, skip => 0, noindent => 1);
+        "$block_deparsed $keyword ($condition_deparsed);" # ; because there's no COPs inside given to generate them
     } else {
+        my $block_deparsed = $block_op->deparse(force_multiline => 1);
         "$keyword ($condition_deparsed) $block_deparsed";
     }
 }
@@ -571,7 +572,7 @@ sub _is_postfix_whereso {
     return( $scope_name eq 'scope'
             and $first_in_scope_op
             and ! $first_in_scope_op->is_null
-            and ! $first_in_scope_op->_ex_name eq 'pp_nextstate'
+            and ! ($first_in_scope_op->_ex_name eq 'pp_nextstate')
         );
 }
 

--- a/lib/Devel/Chitin/OpTree/UNOP.pm
+++ b/lib/Devel/Chitin/OpTree/UNOP.pm
@@ -525,6 +525,56 @@ foreach my $a ( [ pp_preinc     => '++',    1,  0 ],
     *$pp_name = $sub;
 }
 
+sub pp_leavewhereso {
+    my $self = shift;
+
+    my $enter_op = $self->first;
+    my $condition_op = $enter_op->first;
+    my $condition_deparsed = $condition_op->deparse;
+    my $block_op = $condition_op->sibling;
+    my $block_deparsed = $block_op->deparse(force_multiline => 1);
+
+    my $keyword = $condition_op->op->name eq 'smartmatch'
+                    ? 'whereis'
+                    : 'whereso';
+
+    if ($self->_is_postfix_whereso) {
+        "$block_deparsed $keyword ($condition_deparsed)"
+    } else {
+        "$keyword ($condition_deparsed) $block_deparsed";
+    }
+}
+
+# "regular" whereso has a format like:
+# 1-line with braces:
+#   leavewhereso
+#       enterwhereso
+#           condition-op(s)
+#           scope
+#               (ex-)nextstate
+#               block-op(s)
+# or multiline with braces:
+#   leavewhereso
+#       enterwhereso
+#           condition-op(s)
+#           leave
+#               enter
+#               block-op(s)
+# postfix whereso looks like the first one, but missing the nextstate that's
+# the first part of the scope
+sub _is_postfix_whereso {
+    my $self = shift;
+    my $scope_op = $self->first->first->sibling;
+    my $scope_name = $scope_op->op->name;
+
+    my $first_in_scope_op = $scope_name eq 'scope' ? $scope_op->first : undef;
+    return( $scope_name eq 'scope'
+            and $first_in_scope_op
+            and ! $first_in_scope_op->is_null
+            and ! $first_in_scope_op->_ex_name eq 'pp_nextstate'
+        );
+}
+
 1;
 
 __END__

--- a/t/20-optree.t
+++ b/t/20-optree.t
@@ -1119,10 +1119,14 @@ subtest 'given-when-5.27.7' => sub {
                              qq(\t\tprint 'def'),
                              qq(\t}),
                              qq(\tprint 'ghi' whereso (m/ghi/);),
+                             qq(\twhereis ('123') {),
+                             qq(\t\tprint '123'),
+                             qq(\t}),
+                             qq(\tprint '456' whereis (456);),
+                             qq(\tprint 'default case'),
                              qq(})),
     );
 };
-exit;
 
 subtest 'perl-5.12' => sub {
     _run_tests(

--- a/t/20-optree.t
+++ b/t/20-optree.t
@@ -1118,6 +1118,7 @@ subtest 'given-when-5.27.7' => sub {
                              qq(\twhereso (m/def/) {),
                              qq(\t\tprint 'def'),
                              qq(\t}),
+                             qq(\tprint 'ghi' whereso (m/ghi/);),
                              qq(})),
     );
 };

--- a/t/20-optree.t
+++ b/t/20-optree.t
@@ -3,7 +3,7 @@ use warnings;
 
 use Devel::Chitin::OpTree;
 use Devel::Chitin::Location;
-use Test::More tests => 32;
+use Test::More tests => 34;
 
 use Fcntl qw(:flock :DEFAULT SEEK_SET SEEK_CUR SEEK_END);
 use POSIX qw(:sys_wait_h);
@@ -1079,7 +1079,14 @@ subtest 'perl-5.10.1' => sub {
         defined_or => join("\n",q(my $a;),
                                 q(my $rv = $a // 1;),
                                 q($a //= 4)),
-        given_when => use_experimental('switch'),
+    );
+};
+
+subtest 'given-when-5.10.1' => sub {
+    _run_tests(
+        requires_version(v5.10.1),
+        excludes_version(v5.27.7),
+        given_when_5_10 => use_experimental('switch'),
                       join("\n",q(my $a;),
                                 q(given ($a) {),
                                qq(\twhen (1) { print 'one' }),
@@ -1097,6 +1104,24 @@ subtest 'perl-5.10.1' => sub {
                                 q(})),
     );
 };
+
+subtest 'given-when-5.27.7' => sub {
+    _run_tests(
+        requires_version(v5.27.7),
+        given_when_5_27 => use_experimental('switch'),
+                    join("\n",q(my $a;),
+                              q(given ($a) {),
+                             qq(\twhereso (m/abc/) {),
+                             qq(\t\tprint 'abc';),
+                             qq(\t\tprint 'ABC'),
+                             qq(\t}),
+                             qq(\twhereso (m/def/) {),
+                             qq(\t\tprint 'def'),
+                             qq(\t}),
+                             qq(})),
+    );
+};
+exit;
 
 subtest 'perl-5.12' => sub {
     _run_tests(


### PR DESCRIPTION
5.27.7 removes the old syntax for given/when and replaces it with given/whereso/whereis.