### PR TITLE
Delete hash slice

### DIFF
--- a/lib/Devel/Chitin/OpTree.pm
+++ b/lib/Devel/Chitin/OpTree.pm
@@ -646,50 +646,40 @@ sub _maybe_targmy {
     }
 }
 
+sub op_name {
+    my $self = shift;
+    return $self->is_null
+            ? substr($self->_ex_name, 3)  # remove the preceding pp_
+            : $self->op->name;
+}
+
 # return true for scalar things we can assign to
 my %scalar_container_ops = (
     rv2sv => 1,
-    pp_rv2sv => 1,
     padsv => 1,
-    pp_padsv => 1,
 );
 sub is_scalar_container {
     my $self = shift;
-    my $op_name = $self->is_null
-                    ? $self->_ex_name
-                    : $self->op->name;
-    $scalar_container_ops{$op_name};
+    $scalar_container_ops{$self->op_name};
 }
 
 my %array_container_ops = (
     rv2av => 1,
-    pp_rv2av => 1,
     padav => 1,
-    pp_padav => 1,
 );
 sub is_array_container {
     my $self = shift;
-    my $op_name = $self->is_null
-                    ? $self->_ex_name
-                    : $self->op->name;
-    $array_container_ops{$op_name};
+    $array_container_ops{$self->op_name};
 }
 
 my %scopelike_ops = (
     scope => 1,
-    pp_scope => 1,
     leave => 1,
-    pp_leave => 1,
     leavetry => 1,
-    pp_leavetry => 1,
     leavesub => 1,
-    pp_leavesub => 1,
     leaveloop => 1,
-    pp_leaveloop => 1,
     entergiven => 1,
-    pp_entergiven => 1,
     enterwhile => 1,
-    pp_enterwhile => 1,
     #entergiven => 1,        # Part of the reverted given/whereso/whereis from 5.27.7
     #pp_entergiven => 1,
     #enterwhereso => 1,
@@ -697,10 +687,7 @@ my %scopelike_ops = (
 );
 sub is_scopelike {
     my $self = shift;
-    my $op_name = $self->is_null
-                    ? $self->_ex_name
-                    : $self->op->name;
-    $scopelike_ops{$op_name};
+    $scopelike_ops{$self->op_name};
 }
 
 sub is_for_loop {
@@ -1013,6 +1000,14 @@ the same subroutine, the same OpTree object will be returned.
 =item op
 
 Returns the B::OP-related object wrapped by the invocant
+
+=item op_name
+
+Returns the original OP name, even if the OP has been optimized away, and
+without any preceding 'pp_'.  For example, the OP named 'pp_exists' will
+return 'exists', and an optimized away pp_padsv will still return 'padsv'
+even though it's OP is a pp_null.  To get the real OP name without this
+munging, use C<$op->op->name>.
 
 =item parent
 

--- a/lib/Devel/Chitin/OpTree.pm
+++ b/lib/Devel/Chitin/OpTree.pm
@@ -323,6 +323,8 @@ my %flag_values = (
 my %private_values = (
     BARE => B::OPpCONST_BARE,
     TARGMY => B::OPpTARGET_MY,
+    SLICE => B::OPpSLICE,
+    ($^V ge v5.28.0 ? ( KVSLICE => &B::OPpKVSLICE ) : ()),
 );
 sub print_as_tree {
     my $self = shift;

--- a/lib/Devel/Chitin/OpTree/LISTOP.pm
+++ b/lib/Devel/Chitin/OpTree/LISTOP.pm
@@ -171,8 +171,9 @@ sub _aslice_hslice_builder {
         die "unexpected aslice/hslice for $open_paren $close_paren";
     }
 
-    my $sigil = ($self->op->name eq 'kvhslice'
-                 or $self->op->name eq 'kvaslice') ? '%' : '@';
+    my $op_name = $self->op_name;
+    my $sigil = ($op_name eq 'kvhslice'
+                 or $op_name eq 'kvaslice') ? '%' : '@';
 
     my $array_name = substr($self->children->[2]->deparse, 1); # remove the sigil
     "${sigil}${array_name}" . $open_paren . $children->[1]->deparse(skip_parens => 1) . $close_paren;

--- a/t/20-optree.t
+++ b/t/20-optree.t
@@ -3,7 +3,7 @@ use warnings;
 
 use Devel::Chitin::OpTree;
 use Devel::Chitin::Location;
-use Test::More tests => 33;
+use Test::More tests => 34;
 
 use Fcntl qw(:flock :DEFAULT SEEK_SET SEEK_CUR SEEK_END);
 use POSIX qw(:sys_wait_h);
@@ -1287,6 +1287,14 @@ subtest 'perl-5.25.6 split changes' => sub {
         excludes_version(v5.25.6),
         split_specials => join("\n",    q(our @s = split('', $a);),
                                         q(my @strings = split(' ', $a))),
+    );
+};
+
+subtest 'perl-5.28.0' => sub {
+    _run_tests(
+        requires_version(v5.28.0),
+        delete_hash_slice => join("\n", q(my %myhash;),
+                                        q(my %a = delete(%myhash{'baz', 'quux'}))),
     );
 };
 


### PR DESCRIPTION
New syntax in 5.28.0 lets you call delete() on a hash-value slice
```
delete %hash{'key1','key2'}
```