### PR TITLE
Use perl-5.8.9 on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,9 @@ before_install:
 install:
     # Deal with all of the DZIL dependancies, quickly and quietly
     - cpanm --quiet --notest --skip-satisfied Dist::Zilla~'>=5.04, <6.000'
-    - dzil authordeps | grep -vP '[^\w:]' | xargs -n 5 -P 10 cpanm --quiet --notest --skip-satisfied
     - export RELEASE_TESTING=1 AUTOMATED_TESTING=1 AUTHOR_TESTING=1 HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
     - dzil listdeps | grep -vP '[^\w:]' | cpanm --verbose
 
 script:
-
-    - dzil smoke --release --author
+    - dzil smoke
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: perl
 perl:
-  # - "5.8"  # Devel::Callsite doesn't install properly on TravisCI here
+  - "5.8"
   - "5.10"
   - "5.12"
   - "5.14"
@@ -16,6 +16,12 @@ sudo: false
 before_install:
     # Prevent "Please tell me who you are" errors for certain DZIL configs
     - git config --global user.name "TravisCI"
+    - |
+      if perl -e 'if ($] < "5.008009") { exit(0) } else { exit(1) }'; then
+        perlbrew --notest install perl-5.8.9
+        perlbrew use perl-5.8.9
+        perl --version
+      fi
 
 install:
     # Deal with all of the DZIL dependancies, quickly and quietly

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,10 @@ install:
     # Deal with all of the DZIL dependancies, quickly and quietly
     - cpanm --quiet --notest --skip-satisfied Dist::Zilla~'>=5.04, <6.000'
     - export RELEASE_TESTING=1 AUTOMATED_TESTING=1 AUTHOR_TESTING=1 HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
-    - dzil listdeps | grep -vP '[^\w:]' | cpanm --verbose
+    # This is the list from 'dzil listdeps', hardcoded here because Dist::Zilla::Plugin::Git
+    # won't install on perl-5.8.
+    - cpanm --verbose --skip-satisfied --notest B Carp Devel::Callsite Digest::MD5 Exporter ExtUtils::MakeMaker Fcntl File::Basename IO::File IO::Pipe PadWalker POSIX Scalar::Util Socket Sub::Name Test::Builder Test::More
 
 script:
-    - dzil smoke
+    - prove -l
 


### PR DESCRIPTION
Asking for "5.8" in TravisCI installs 5.8.8 which isn't supported by anything.
Install perl-5.8.9 before testing