### PR TITLE
Deparse optimized index

### DIFF
--- a/lib/Devel/Chitin/OpTree/LISTOP.pm
+++ b/lib/Devel/Chitin/OpTree/LISTOP.pm
@@ -584,7 +584,6 @@ sub pp_grepstart { 'grep' }
 
 #                 OP name           Perl fcn    targmy?
 foreach my $a ( [ pp_crypt      => 'crypt',     1 ],
-                [ pp_rindex     => 'rindex',    1 ],
                 [ pp_pack       => 'pack',      0 ],
                 [ pp_reverse    => 'reverse',   0 ],
                 [ pp_sprintf    => 'sprintf',   0 ],
@@ -664,23 +663,28 @@ foreach my $a ( [ pp_crypt      => 'crypt',     1 ],
 my($INDEX_BOOLNEG, $INDEX_TRUEBOOL) = $^V ge v5.28.0
                                     ? (B::OPpINDEX_BOOLNEG(), B::OPpTRUEBOOL())
                                     : (0,0);
+foreach my $index_fcn ( 'index', 'rindex') {
+    my $pp_name = "pp_${index_fcn}";
 
-sub pp_index {
-    my $self = shift;
+    my $sub = sub {
+        my $self = shift;
 
-    my $target = $self->_maybe_targmy;
-    my $children = $self->children;
-    my $deparsed = "${target}index("
-                   . join(', ', map { $_->deparse } @$children[1 .. $#$children]) # [0] is pushmark
-                   . ')';
+        my $target = $self->_maybe_targmy;
+        my $children = $self->children;
+        my $deparsed = "${target}${index_fcn}("
+                       . join(', ', map { $_->deparse } @$children[1 .. $#$children]) # [0] is pushmark
+                       . ')';
 
-    my $private_flags = $self->op->private;
-    if ($private_flags & $INDEX_TRUEBOOL) {
-        my $operator = $self->op->private & $INDEX_BOOLNEG ? '==' : '!=';
-        "$deparsed $operator -1";
-    } else {
-        $deparsed;
-    }
+        my $private_flags = $self->op->private;
+        if ($private_flags & $INDEX_TRUEBOOL) {
+            my $operator = $self->op->private & $INDEX_BOOLNEG ? '==' : '!=';
+            "$deparsed $operator -1";
+        } else {
+            $deparsed;
+        }
+    };
+    no strict 'refs';
+    *$pp_name = $sub;
 }
 
 1;

--- a/lib/Devel/Chitin/OpTree/LISTOP.pm
+++ b/lib/Devel/Chitin/OpTree/LISTOP.pm
@@ -661,7 +661,10 @@ foreach my $a ( [ pp_crypt      => 'crypt',     1 ],
     *$pp_name = $sub;
 }
 
-my $INDEX_BOOLNEG = $^V ge v5.28.0 ? B::OPpINDEX_BOOLNEG() : 0;
+my($INDEX_BOOLNEG, $INDEX_TRUEBOOL) = $^V ge v5.28.0
+                                    ? (B::OPpINDEX_BOOLNEG(), B::OPpTRUEBOOL())
+                                    : (0,0);
+
 sub pp_index {
     my $self = shift;
 
@@ -671,8 +674,10 @@ sub pp_index {
                    . join(', ', map { $_->deparse } @$children[1 .. $#$children]) # [0] is pushmark
                    . ')';
 
-    if ($self->op->private & $INDEX_BOOLNEG) {
-        "$deparsed == -1";
+    my $private_flags = $self->op->private;
+    if ($private_flags & $INDEX_TRUEBOOL) {
+        my $operator = $self->op->private & $INDEX_BOOLNEG ? '==' : '!=';
+        "$deparsed $operator -1";
     } else {
         $deparsed;
     }

--- a/t/20-optree.t
+++ b/t/20-optree.t
@@ -1295,6 +1295,11 @@ subtest 'perl-5.28.0' => sub {
         requires_version(v5.28.0),
         delete_hash_slice => join("\n", q(my %myhash;),
                                         q(my %a = delete(%myhash{'baz', 'quux'}))),
+
+        optimized_index   => join("\n", q(my $a = 'abcd';),
+                                        q(if (index($a, 'q') == -1) {),
+                                       qq(\tprint 'no'),
+                                        q(})),
     );
 };
 

--- a/t/20-optree.t
+++ b/t/20-optree.t
@@ -1299,6 +1299,8 @@ subtest 'perl-5.28.0' => sub {
         optimized_index   => join("\n", q(my $a = 'abcd';),
                                         q(if (index($a, 'q') == -1) {),
                                        qq(\tprint 'no'),
+                                        q(} elsif (index($a, 'q') != -1) {),
+                                       qq(\tprint 'yes'),
                                         q(})),
     );
 };

--- a/t/20-optree.t
+++ b/t/20-optree.t
@@ -159,7 +159,7 @@ subtest 'string functions' => sub {
                                 q(index($a, 'foo', 1))),
         rindex_fcn  => join("\n",   q(my $a;),
                                     q($a = rindex($a, 'foo');),
-                                    q(index($a, 'foo', 1))),
+                                    q(rindex($a, 'foo', 1))),
         substr_fcn  => join("\n",   q(my $a;),
                                     q($a = substr($a, 1, 2, 'foo');),
                                     q(substr($a, 2, 3) = 'bar';),  # doubled because the first one triggers an optimized-out

--- a/t/20-optree.t
+++ b/t/20-optree.t
@@ -156,10 +156,14 @@ subtest 'string functions' => sub {
                                 q(crypt($a, 'salt'))),
         index_fcn => join("\n", q(my $a;),
                                 q($a = index($a, 'foo');),
-                                q(index($a, 'foo', 1))),
+                                q(index($a, 'foo', 1);),
+                                q($a = index($a, 'foo') == -1;),
+                                q($a = index($a, 'foo') != -1)),
         rindex_fcn  => join("\n",   q(my $a;),
                                     q($a = rindex($a, 'foo');),
-                                    q(rindex($a, 'foo', 1))),
+                                    q(rindex($a, 'foo', 1);),
+                                    q($a = rindex($a, 'foo') == -1;),
+                                    q($a = rindex($a, 'foo') != -1)),
         substr_fcn  => join("\n",   q(my $a;),
                                     q($a = substr($a, 1, 2, 'foo');),
                                     q(substr($a, 2, 3) = 'bar';),  # doubled because the first one triggers an optimized-out
@@ -1295,19 +1299,6 @@ subtest 'perl-5.28.0' => sub {
         requires_version(v5.28.0),
         delete_hash_slice => join("\n", q(my %myhash;),
                                         q(my %a = delete(%myhash{'baz', 'quux'}))),
-
-        optimized_index   => join("\n", q(my $a = 'abcd';),
-                                        q(if (index($a, 'q') == -1) {),
-                                       qq(\tprint 'no'),
-                                        q(} elsif (index($a, 'q') != -1) {),
-                                       qq(\tprint 'yes'),
-                                        q(})),
-        optimized_rindex  => join("\n", q(my $a = 'abcd';),
-                                        q(if (rindex($a, 'q') == -1) {),
-                                       qq(\tprint 'no'),
-                                        q(} elsif (rindex($a, 'q') != -1) {),
-                                       qq(\tprint 'yes'),
-                                        q(})),
     );
 };
 

--- a/t/20-optree.t
+++ b/t/20-optree.t
@@ -1302,6 +1302,12 @@ subtest 'perl-5.28.0' => sub {
                                         q(} elsif (index($a, 'q') != -1) {),
                                        qq(\tprint 'yes'),
                                         q(})),
+        optimized_rindex  => join("\n", q(my $a = 'abcd';),
+                                        q(if (rindex($a, 'q') == -1) {),
+                                       qq(\tprint 'no'),
+                                        q(} elsif (rindex($a, 'q') != -1) {),
+                                       qq(\tprint 'yes'),
+                                        q(})),
     );
 };
 


### PR DESCRIPTION
Perl 5.28 optimizes index() and rindex() when they are compared to -1.  The deparsing needs to handle this case.