### PR TITLE
Implement continue_to()

### DIFF
--- a/t/03-continue-to.t
+++ b/t/03-continue-to.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+
+use Test2::V0; no warnings 'void';
+use lib 't/lib';
+use TestHelper qw(ok_location ok_set_breakpoint db_continue_to db_continue);
+
+# Since debugging isn't enabled until 'use TestHelper',
+# this file's lines don't show up in the _<$filename, and we can't set
+# breakpoints that get honored.  Starting a new compilation unit with
+# use gets around that problem.
+use SampleCode;
+
+$DB::single=1;
+14;
+15;
+SampleCode::looper();
+SampleCode::foo();
+19;
+SampleCode::foo();
+$DB::single=1;
+22;
+
+sub __tests__ {
+    plan tests => 5;
+
+    my $file = 't/lib/SampleCode.pm';
+
+    ok_set_breakpoint line => 15, code => 1, file => $file, 'Set unconditional breakpoint';  # within looper()
+    db_continue_to $file, 13;
+
+    ok_location line => 13, filename => $file;
+    db_continue_to 'SampleCode::foo';
+
+    ok_location line => 15, filename => $file;  # This was the breakpoint we set
+    db_continue;
+
+    ok_location line => 5, filename => $file;   # This was the continue_to
+    db_continue;
+
+    ok_location line => 22, filename => __FILE__;
+};
+

--- a/t/lib/TestHelper.pm
+++ b/t/lib/TestHelper.pm
@@ -17,7 +17,7 @@ our @EXPORT_OK = qw(ok_location ok_breakable ok_not_breakable ok_trace_location
                     ok_at_end
                     is_eval is_eval_exception is_var_at_level
                     do_test do_disable_auto_disable
-                    db_step db_continue db_stepout db_stepover db_trace db_disable
+                    db_step db_continue db_continue_to db_stepout db_stepover db_trace db_disable
                     has_callsite
                 );
 
@@ -398,6 +398,16 @@ sub db_step {
 sub db_continue {
     push @TEST_QUEUE, sub {
         __PACKAGE__->continue;
+        no warnings 'exiting';
+        last TEST_QUEUE_LOOP;
+    }
+}
+
+sub db_continue_to {
+    my @params = @_;
+
+    push @TEST_QUEUE, sub {
+        __PACKAGE__->continue_to( @params );
         no warnings 'exiting';
         last TEST_QUEUE_LOOP;
     }


### PR DESCRIPTION
Accepts a file+line and sets a once breakpoint there.
Also accepts a subname/subref and sets a once breakpoint on the first breakable
line within the sub.

This fixes #15 