### PR TITLE
Allow a coderef in an Actionable

### DIFF
--- a/lib/Devel/Chitin.pm
+++ b/lib/Devel/Chitin.pm
@@ -585,8 +585,13 @@ sub is_breakpoint {
         foreach my $condition ( @{ $dbline{$line}->{$breakpoint_key} }) {
             next if $condition->inactive;
             my $code = $condition->code;
+
+            no warnings 'uninitialized';
             if ($code eq '1') {
                 $should_break = 1;
+            } elsif (Scalar::Util::reftype($code) eq 'CODE') {
+                local $@;
+                $should_break = eval { $code->() };
             } else {
                 ($should_break) = _eval_in_program_context($condition->code, 0);
             }

--- a/lib/Devel/Chitin/Actionable.pm
+++ b/lib/Devel/Chitin/Actionable.pm
@@ -206,10 +206,14 @@ code before a line in the debugged program executes.
 =head1 Breakpoints
 
 Breakpoints are associated with a file and line number, and the same
-file/line combination may have more than one breakpoint.  At each line
-with one or more breakpoints, all those breakpoints are tested by
-eval-ing (as a string eval) their C<code> in the context of the debugged
-program.  If any of these tests returns true, the debugger will stop the
+file/line combination may have more than one breakpoint.  Before executing a
+line with one or more breakpoints, all those breakpoints with string C<code>
+attributes are tested by eval-ing, as a string eval, their C<code> in the
+context of the debugged program; these can be used to implement a conditional
+breakpoint that stops depending on some condition in the program code.
+Coderef C<code> attributes are called directly, and get no special scoping.
+
+If any of these tests returns true, the debugger will stop the
 program before executing that line.
 
 =head2 Constructor
@@ -225,6 +229,11 @@ is omitted, the value "1" is used as a default which creates an unconditional
 breakpoint.  If C<once> is a true value, then the breakpoint will delete
 itself after triggering.  If C<inactive> is true, the breakpoint will not
 trigger.
+
+The breakpoint code can be either a string or a coderef.  Strings are executed
+as a string-eval, and are evaluated in the context of the program being
+debugged.  Coderefs are called directly, and behave according to normal
+scoping rules.
 
 =head2 Methods
 
@@ -269,8 +278,9 @@ Actions are a lot like breakpoints; they are associated with a file and line
 number, and they have code that runs before that line in the program is
 executed.  The difference is that the return value from the code is ignored.
 
-The code is evaluated in the context of the running program, so it can, for
-example, affect variables there or print them out.
+The code is evaluated in the context of the running program if specified as
+a string, so it can, for example, affect variables there or print them out.
+Coderefs are called directly, and get no special scoping.
 
 =head2 Constructor
 

--- a/t/04-conditional-breakpoint.t
+++ b/t/04-conditional-breakpoint.t
@@ -10,16 +10,20 @@ $DB::single=1;
 SampleCode::takes_param(1);
 SampleCode::takes_param(2);
 SampleCode::takes_param(3);
+SampleCode::looper();
+
 $DB::single=1;
-14;
+16;
 
 sub __tests__ {
-    plan tests => 6;
+    plan tests => 9;
 
     my $file = 't/lib/SampleCode.pm';
     ok_set_breakpoint line => 19, file => $file, code => '0', 'Set conditional breakpoint that will never fire';
     ok_set_breakpoint line => 21, file => $file, code => '$a == 1', 'Set conditional breakpoint $a == 1';
     ok_set_breakpoint line => 20, file => $file, code => '$a == 2', 'Set conditional breakpoint $a == 2';
+    ok_set_breakpoint line => 13, file => $file, code => sub { rand() > 1 }, 'Set coderef conditional that will not fire';
+    ok_set_breakpoint line => 15, file => $file, code => sub { 1 }, 'Set coderef unconditional';
 
     db_continue;
     ok_location filename => $file, line => 21;
@@ -28,6 +32,9 @@ sub __tests__ {
     ok_location filename => $file, line => 20;
 
     db_continue;
-    ok_location filename => __FILE__, line => 14;
+    ok_location filename => $file, line => 15;
+
+    db_continue;
+    ok_location filename => __FILE__, line => 16;
 }
 


### PR DESCRIPTION
This allows supplying a coderef in addition to a string as the 'code' part of an Action or Breakpoint.  It also updates the docs explaining its limitations.

This fixes #9 