### PR TITLE
For perl-5.30, dump() must be called as CORE::dump()

### DIFF
--- a/lib/Devel/Chitin/OpTree.pm
+++ b/lib/Devel/Chitin/OpTree.pm
@@ -484,7 +484,7 @@ sub pp_stub { ';' }
 sub pp_unstack { '' }
 sub pp_undef { 'undef' }
 sub pp_wantarray { 'wantarray' }
-sub pp_dump { 'dump' }
+sub pp_dump { 'CORE::dump' }
 sub pp_next { 'next' }
 sub pp_last { 'last' }
 sub pp_redo { 'redo' }

--- a/lib/Devel/Chitin/OpTree/PVOP.pm
+++ b/lib/Devel/Chitin/OpTree/PVOP.pm
@@ -9,7 +9,7 @@ use warnings;
 use Config;
 
 sub pp_dump {
-    'dump ' . shift->op->pv;
+    'CORE::dump ' . shift->op->pv;
 }
 
 sub pp_goto {

--- a/lib/Devel/Chitin/OpTree/UNOP.pm
+++ b/lib/Devel/Chitin/OpTree/UNOP.pm
@@ -403,7 +403,7 @@ foreach my $a ( [ pp_scalar     => 'scalar',    0 ],
 }
 
 # These look like keywords but take an argument
-foreach my $a ( [ pp_dump       => 'dump' ],
+foreach my $a ( [ pp_dump       => 'CORE::dump' ],
                 [ pp_next       => 'next' ],
                 [ pp_last       => 'last' ],
                 [ pp_redo       => 'redo' ],

--- a/t/20-optree-deparse/14-program-flow/dump
+++ b/t/20-optree-deparse/14-program-flow/dump
@@ -1,4 +1,4 @@
 no warnings 'misc'; # omit
 no warnings 'deprecated'; # omit
-dump;
-dump DUMP_LABEL
+CORE::dump;
+CORE::dump DUMP_LABEL

--- a/t/20-optree-deparse/24-perl-5.18/dump-expr
+++ b/t/20-optree-deparse/24-perl-5.18/dump-expr
@@ -3,5 +3,5 @@ use v5.18.0; # omit
 no warnings 'misc'; # omit
 no warnings 'deprecated'; # omit
 my $expr;
-dump $expr;
-dump 'foo' . $expr
+CORE::dump $expr;
+CORE::dump 'foo' . $expr


### PR DESCRIPTION
References:

https://rt.perl.org/Ticket/Display.html?id=133602
https://rt.cpan.org/Ticket/Display.html?id=127414