### PR TITLE
Fixes for 0.17 test failures

### DIFF
--- a/t/07-stack.t
+++ b/t/07-stack.t
@@ -24,7 +24,7 @@ sub AUTOLOAD {
 }
 
 package main;
-use List::Util qw(uniq);
+use List::Util 1.45, 'uniq';
 
 sub __tests__ {
     plan tests => 13;

--- a/t/22-sub-name-bug.t
+++ b/t/22-sub-name-bug.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test2::V0;
+use Test2::V0; no warnings 'void';
 use lib 't/lib';
 use TestHelper qw(db_continue do_test);
 use Sub::Name;

--- a/t/lib/TestHelper.pm
+++ b/t/lib/TestHelper.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 use Test2::V0;
-use Test2::API qw( context_do context run_subtest test2_add_callback_testing_done);
+use Test2::API 1.302136, qw( context_do context run_subtest test2_add_callback_testing_done);
 use base 'Devel::Chitin';
 use Carp;
 

--- a/t/lib/TestHelper.pm
+++ b/t/lib/TestHelper.pm
@@ -1,6 +1,8 @@
 package   # CPAN, don't index
     TestHelper;
 
+BEGIN { $^P = 0x400 }  # Turn on source code saving into @main::{"_<$filename"}
+
 use strict;
 use warnings;
 
@@ -488,5 +490,5 @@ sub has_callsite {
 
 __PACKAGE__->attach();
 
-$^P = 0x73f;  # Turn on all the debugging stuff
+BEGIN { $^P = 0x73f }  # Turn on all the debugging stuff
 INIT { $START_TESTING = 1 }


### PR DESCRIPTION
There were 3 bug reports soon after the 0.17 release:
https://rt.cpan.org/Ticket/Display.html?id=127437
https://rt.cpan.org/Ticket/Display.html?id=127438
https://rt.cpan.org/Ticket/Display.html?id=127439

These commits fix these reports