### PR TITLE
Eval stack frames don't have a @_

### DIFF
--- a/lib/Devel/Chitin/Stack.pm
+++ b/lib/Devel/Chitin/Stack.pm
@@ -52,7 +52,9 @@ sub new {
 
         #next if $skip;
 
-        $caller{args} = [ @DB::args ];
+        # For eval frames, @DB::args is actually @_ for the enclosing sub's
+        # frame, and doesn't have a @_ of its own.
+        $caller{args} = $caller{subroutine} eq '(eval)' ? undef : [ @DB::args ];
         $caller{callsite} = Devel::Chitin::Location::get_callsite($level);
 
         # subname is the subroutine without the package part

--- a/t/07-stack.t
+++ b/t/07-stack.t
@@ -72,7 +72,7 @@ sub __tests__ {
                 field is_require => DF();
                 field autoload   => U();
                 field subname    => '(eval)';
-                field args       => [];
+                field args       => U();
                 field serial     => T();
                 field bitmask    => T();
                 field callsite   => $expected_callsite;
@@ -92,7 +92,7 @@ sub __tests__ {
                 field is_require => U();
                 field autoload   => U();
                 field subname    => '(eval)';
-                field args       => [];
+                field args       => U();
                 field serial     => T();
                 field bitmask    => T();
                 field callsite   => $expected_callsite;


### PR DESCRIPTION
These stack frames' "args" property was showing @_ from the enclosing sub.
Since evals don't have their own @_, represent this by putting in undef here.
A real sub called with no args will have an empty list.

This fixes #16