### PR TITLE
sysseek() deparse failure

### DIFF
--- a/lib/Devel/Chitin/OpTree/SVOP.pm
+++ b/lib/Devel/Chitin/OpTree/SVOP.pm
@@ -20,11 +20,11 @@ sub pp_const {
             return $mg->PTR if $mg->TYPE eq 'V';
         }
 
-    } elsif ($sv->isa('B::PV') and $sv->FLAGS & B::SVf_POK) {
+    } elsif ($sv->FLAGS & B::SVf_POK) {
         return $self->_quote_sv($sv, %params);
-    } elsif ($sv->isa('B::NV')) {
+    } elsif ($sv->FLAGS & B::SVf_NOK) {
         return $sv->NV;
-    } elsif ($sv->isa('B::IV')) {
+    } elsif ($sv->FLAGS & B::SVf_IOK) {
         return $sv->int_value;
     } elsif ($sv->isa('B::SPECIAL')) {
         '<???pp_const B::SPECIAL ' .  $B::specialsv_name[$$sv] . '>';

--- a/lib/Devel/Chitin/OpTree/SVOP.pm
+++ b/lib/Devel/Chitin/OpTree/SVOP.pm
@@ -20,7 +20,7 @@ sub pp_const {
             return $mg->PTR if $mg->TYPE eq 'V';
         }
 
-    } elsif ($sv->isa('B::PV')) {
+    } elsif ($sv->isa('B::PV') and $sv->FLAGS & B::SVf_POK) {
         return $self->_quote_sv($sv, %params);
     } elsif ($sv->isa('B::NV')) {
         return $sv->NV;

--- a/t/20-optree-deparse.t
+++ b/t/20-optree-deparse.t
@@ -80,6 +80,7 @@ sub run_one_test {
 
     (my $expected = $test_code) =~ s/\b(?:my|our)\b\s*//mg;
     $expected =~ s/^.*?# omit\n//mg;  # remove lines that don't deparse to anything
+    $expected =~ s/^.*?# deparsed: (.*?\n)/$1/mg; # Lines that are expected to deparse differently
     $expected =~ s/\s*(?<!\$)#.*?$//mg;  # remove comments and don't match $#something
     $expected =~ s/^\n//mg; # remove empty lines
 

--- a/t/20-optree-deparse/01-assignment/scalar_dualvar_assignment
+++ b/t/20-optree-deparse/01-assignment/scalar_dualvar_assignment
@@ -1,0 +1,5 @@
+# dual-vars where the upgraded-type is invalid
+use constant dualvar_PVIV => do { my $val = "One"; $val = 1; $val }; # omit
+use constant dualvar_PVNV => do { my $val = "OnePointOne"; $val = 1.1; $val }; # omit
+my $foo = dualvar_PVIV; # deparsed: my $foo = 1;
+my $bar = dualvar_PVNV # deparsed: my $bar = 1.1


### PR DESCRIPTION
Turns out, this is actually a failure to properly deparse dualvars (PVIVs and PVNVs).

This fixes #80 