### PR TITLE
Decompile opcode pp_padsv_store

### DIFF
--- a/lib/Devel/Chitin/OpTree/UNOP.pm
+++ b/lib/Devel/Chitin/OpTree/UNOP.pm
@@ -476,6 +476,14 @@ sub pp_require {
     shift->first->deparse;
 };
 
+sub pp_padsv_store {
+    my $self = shift;
+
+    my $var = $self->_padname_sv->PV;
+    my $value = $self->first->deparse;
+    join(' = ', $var, $value);
+}
+
 sub pp_sassign {
     my $self = shift;
     # This is likely an optimized-out assignment where substr is being


### PR DESCRIPTION
Perl 5.37.3 added a new opcode OP_PADSV_STORE to improve the performance of assignment of my-scalars by combining padsv and sassign into one opcode.

This fixes #83