### PR TITLE
Decompile opcode pp_aelemfastlex_store

### DIFF
--- a/lib/Devel/Chitin/OpTree/UNOP.pm
+++ b/lib/Devel/Chitin/OpTree/UNOP.pm
@@ -484,6 +484,15 @@ sub pp_padsv_store {
     join(' = ', $var, $value);
 }
 
+sub pp_aelemfastlex_store {
+    my $self = shift;
+    my $var = $self->_padname_sv->PV;
+    my $idx = $self->op->private;
+    my $value = $self->first->deparse;
+    substr($var, 0, 1) = '$';
+    "${var}[${idx}] = $value";
+}
+
 sub pp_sassign {
     my $self = shift;
     # This is likely an optimized-out assignment where substr is being


### PR DESCRIPTION
Perl 5.37.3 added a new opcode OP_AELEMFASTLEX_STORE to improve the performance of assignment to array elems by combining padsv and index lookup into one opcode

This fixes #86