### PR TITLE
Deparse new undef-related optimizations

### DIFF
--- a/lib/Devel/Chitin/OpTree.pm
+++ b/lib/Devel/Chitin/OpTree.pm
@@ -479,10 +479,16 @@ foreach my $d ( [ pp_chdir => 'chdir' ],
     *$pp_name = $sub;
 }
 
+sub pp_undef {
+    my $self = shift;
+
+    my $target = $self->_maybe_targmy;
+    "${target}undef";
+}
+
 sub pp_enter { '' }
 sub pp_stub { ';' }
 sub pp_unstack { '' }
-sub pp_undef { 'undef' }
 sub pp_wantarray { 'wantarray' }
 sub pp_dump { 'CORE::dump' }
 sub pp_next { 'next' }

--- a/lib/Devel/Chitin/OpTree/BINOP.pm
+++ b/lib/Devel/Chitin/OpTree/BINOP.pm
@@ -17,11 +17,22 @@ sub last {
 
 sub pp_sassign {
     my($self, %params) = @_;
-    # normally, the args are ordered: value, variable
-    my($var, $value) = $params{is_swapped}
-                        ? ($self->first->deparse, $self->last->deparse)
-                        : ($self->last->deparse, $self->first->deparse);
-    return join(' = ', $var, $value);
+
+    if ($self->is_null
+        and
+        $self->first->op->name eq 'undef'
+        and
+        ( $self->last->is_null and $self->last->_ex_name eq 'pp_padsv')
+    ) {
+        # This is an optimised undef-assignment
+        $self->first->deparse();
+    } else {
+        # normally, the args are ordered: value, variable
+        my($var, $value) = $params{is_swapped}
+                            ? ($self->first->deparse, $self->last->deparse)
+                            : ($self->last->deparse, $self->first->deparse);
+        return join(' = ', $var, $value);
+    }
 }
 
 sub pp_aassign {

--- a/lib/Devel/Chitin/OpTree/UNOP.pm
+++ b/lib/Devel/Chitin/OpTree/UNOP.pm
@@ -262,9 +262,16 @@ sub pp_readline {
 sub pp_undef {
     #'undef(' . shift->first->deparse . ')'
     my $self = shift;
-    my $arg = $self->first->deparse;
-    if ($arg =~ m/::/) {
+
+    my $arg;
+    if ($self->first->is_null and $self->op->private & B::OPpTARGET_MY) {
+        # This is an optimized undef($myvar)
+        $arg = $self->_padname_sv->PV;
+    } else {
         $arg = $self->first->deparse;
+        if ($arg =~ m/::/) {
+            $arg = $self->first->deparse;
+        }
     }
     "undef($arg)";
 }


### PR DESCRIPTION
undef as a value and a function got optimizations where the target of the value gets encoded directly in the undef OP.

This fixes #84