### PR TITLE
Extract pp_anoncode handling to SVOP

### DIFF
--- a/lib/Devel/Chitin/OpTree/SVOP.pm
+++ b/lib/Devel/Chitin/OpTree/SVOP.pm
@@ -42,6 +42,19 @@ sub pp_gv {
 }
 *pp_gvsv = \&pp_gv;
 
+sub pp_anoncode {
+    my $self = shift;
+
+    my $subref = $self->_padval_sv($self->op->targ);
+    my $deparser = Devel::Chitin::OpTree->build_from_location($subref->object_2svref);
+    my $deparsed = $deparser->deparse;
+    if ($deparsed =~ m/\n/) {
+        return join('', 'sub {', $self->_indent_block_text($deparsed), '}');
+    } else {
+        return join('', 'sub { ', $deparsed, ' }');
+    }
+}
+
 1;
 
 __END__

--- a/lib/Devel/Chitin/OpTree/UNOP.pm
+++ b/lib/Devel/Chitin/OpTree/UNOP.pm
@@ -60,14 +60,7 @@ sub pp_refgen {
     }
 
     if ($anoncode) {
-        my $subref = $self->_padval_sv($anoncode->op->targ);
-        my $deparser = Devel::Chitin::OpTree->build_from_location($subref->object_2svref);
-        my $deparsed = $deparser->deparse;
-        if ($deparsed =~ m/\n/) {
-            return join('', 'sub {', $self->_indent_block_text($deparsed), '}');
-        } else {
-            return join('', 'sub { ', $deparsed, ' }');
-        }
+        return $anoncode->pp_anoncode()
 
     } elsif ($first->is_null
              and $first->_ex_name eq 'pp_list'


### PR DESCRIPTION
5.37.5 compiles a construct like
    my $a = sub { ... }
differently than before.  We were handling the pp_anoncode opcode within the pp_refgen opcode handler before.  This new arrangement works for both the old and new opcode constructs

This fixes #91